### PR TITLE
Further example of inheritances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 *.exe
 *.out
 *.app
+
+#MAC Specific
+.DS_store

--- a/Polygon.cpp
+++ b/Polygon.cpp
@@ -30,3 +30,9 @@ void Polygon::setHeight(int height) {
 void Polygon::setWidth(int width) {
 	m_width = width;
 }
+
+// Returns the area. NOTE: This is a polymorphic function, and individual classes might have their own implementation.
+int Polygon::area()
+{
+	return m_height * m_height;
+}

--- a/Polygon.h
+++ b/Polygon.h
@@ -22,7 +22,7 @@ public:
 	void setWidth(int width);
 
 	// Virtual area method
-	virtual int area() = 0;
+	virtual int area();
 
 protected:
 	// Member variables

--- a/Square.cpp
+++ b/Square.cpp
@@ -10,8 +10,3 @@ Square::Square(int height, int width): Polygon(height, width) {}
 
 // Destructor
 Square::~Square() {}
-
-// Returns the area of the square
-int Square::area() {
-	return m_height * m_width;
-}

--- a/Square.h
+++ b/Square.h
@@ -14,9 +14,7 @@ public:
 	Square(int height, int width);
 	// Trivial Destructor
 	~Square();
-
-	// Area method (polymorphic)
-	int area();
+	
 };
 
 #endif  // SQUARE_H_

--- a/main.cpp
+++ b/main.cpp
@@ -9,30 +9,42 @@
 #include "Square.h"
 #include "Triangle.h"
 
+// Prints out some details on a Polygon.
+// Note that it's not passing through a particular Polygon (like Triangle or Square), rather it's the parent.
+void printDetails(Polygon* shape)
+{
+	std::cout << "Height: " << shape->getHeight();
+	std::cout << ", Width: " << shape->getWidth();
+
+	// Pay particular attention to the results of area(). Even though it's a Polygon, the children produce different results for the function call.
+	std::cout << ", Area: " << shape->area();
+	std::cout << std::endl;
+}
+
 int main() {
 	// Create a square on the heap with a height of 5 and a width of 6
 	Polygon* square = new Square(5, 6);
 	// Print information using getters and method
-	std::cout << "Height: " << square->getHeight() << ", Width: " << square->getHeight() << ", Area: " << square->area() << std::endl;
+	printDetails(square);
 	// Set the height to 10 with a setter
 	square->setHeight(10);
 	// Set the width to 10 with a setter
 	square->setWidth(10);
 	// Print information using getters and method
-	std::cout << "Height: " << square->getHeight() << ", Width: " << square->getHeight() << ", Area: " << square->area() << std::endl;
+	printDetails(square);
 	// Cleanup the memory in the heap
 	delete square;
 
 	// Create a triangle on the heap with a height of 7 and a width of 8
 	Polygon* triangle = new Triangle(7, 8);
 	// Print information using getters and method
-	std::cout << "Height: " << triangle->getHeight() << ", Width: " << triangle->getHeight() << ", Area: " << triangle->area() << std::endl;
+	printDetails(triangle);
 	// Set the height to 3 with a setter
 	triangle->setHeight(3);
 	// Set the width to 4 with a setter
 	triangle->setWidth(4);
 	// Print information using getters and method
-	std::cout << "Height: " << triangle->getHeight() << ", Width: " << triangle->getHeight() << ", Area: " << triangle->area() << std::endl;
+	printDetails(triangle);
 	// Cleanup the memory in the heap
 	delete triangle;
 


### PR DESCRIPTION
Hopefully trying to show a bit more about inheritance by adding an example of passing through a parents pointer (could do more on slicing here), as well as using virtual instead of pure virtual.

Commit changes as below:
- Added standard area() to polygon (to show parent calls still work)
- Added printer function to main to show the passing of the parents pointer, not the individual object itself. Demonstrates a bit more about inheritance.
- Made Polygon no longer pure virtual, just virtual
- Removed squares area() in place for the parent's area()
